### PR TITLE
Removed 'meta.method' selector from "Function, Special Method, Block Lev...

### DIFF
--- a/Behave.tmTheme
+++ b/Behave.tmTheme
@@ -114,7 +114,7 @@
             <key>name</key>
             <string>Function, Special Method, Block Level</string>
             <key>scope</key>
-            <string>entity.name.function, meta.function-call, support.function, keyword.other.special-method, meta.method, meta.accessor, meta.block-level, function.name</string>
+            <string>entity.name.function, meta.function-call, support.function, keyword.other.special-method, meta.accessor, meta.block-level, function.name</string>
             <key>settings</key>
             <dict>
                 <key>fontStyle</key>


### PR DESCRIPTION
...el" to prevent matching entire method bodies in Java source files